### PR TITLE
Add deserialization for ICS

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: example
 environment:
   sdk: '>=2.1.0 <3.0.0'
 dependencies:
-  intl: ^0.15.7
-  nanoid: ^0.0.6
+  intl: any
+  nanoid: any
   ical:
     path: ..
   

--- a/lib/src/abstract.dart
+++ b/lib/src/abstract.dart
@@ -1,4 +1,5 @@
 import 'package:ical/serializer.dart';
+import 'package:ical/src/structure.dart';
 import 'package:ical/src/utils.dart';
 
 import 'utils.dart' as utils;
@@ -7,6 +8,10 @@ import 'package:nanoid/nanoid.dart';
 
 abstract class AbstractSerializer {
   String serialize();
+}
+
+abstract class AbstractDeserializer {
+  void deserialize(ICalStructure structure);
 }
 
 class IClass {
@@ -105,7 +110,7 @@ class IOrganizer {
   }
 }
 
-abstract class ICalendarElement extends AbstractSerializer {
+abstract class ICalendarElement implements AbstractSerializer, AbstractDeserializer {
   IOrganizer organizer;
   String uid;
   String summary;
@@ -149,6 +154,19 @@ abstract class ICalendarElement extends AbstractSerializer {
 
     return out.toString();
   }
+
+  @override
+  void deserialize(ICalStructure structure) {
+    uid = structure["UID"]?.value;
+    categories = structure["CATEGORIES"]?.value?.split(",");
+    comment = structure["COMMENT"]?.value;
+    summary = structure["SUMMARY"]?.value;
+    url = structure["URL"]?.value;
+    final classificationString = structure["CLASSIFICATION"]?.value;
+    if(classificationString != null) classification = IClass._(classificationString);
+    // TODO support rrule
+  }
+
   // TODO ATTENDEE
   // TODO CONTACT
 }

--- a/lib/src/calendar.dart
+++ b/lib/src/calendar.dart
@@ -1,7 +1,10 @@
+import 'package:ical/serializer.dart';
+import 'package:ical/src/structure.dart';
+
 import 'abstract.dart';
 import 'utils.dart' as utils;
 
-class ICalendar extends AbstractSerializer {
+class ICalendar implements AbstractSerializer, AbstractDeserializer {
   List<ICalendarElement> _elements = <ICalendarElement>[];
   String company;
   String product;
@@ -17,6 +20,8 @@ class ICalendar extends AbstractSerializer {
 
   addAll(List<ICalendarElement> elements) => _elements.addAll(elements);
   addElement(ICalendarElement element) => _elements.add(element);
+
+  List<IEvent> get events => _elements.whereType<IEvent>().toList();
 
   @override
   String serialize() {
@@ -36,5 +41,15 @@ class ICalendar extends AbstractSerializer {
 
     out.writeln('END:VCALENDAR');
     return out.toString();
+  }
+
+  @override
+  void deserialize(ICalStructure structure) {
+    _elements = structure
+        .children
+        .where((child) => child.type == "VEVENT")
+        .map((event) => IEvent()..deserialize(event))
+        .cast<ICalendarElement>()
+        .toList();
   }
 }

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -1,3 +1,5 @@
+import 'package:ical/src/structure.dart';
+
 import 'abstract.dart';
 import 'subcomponents.dart';
 import 'utils.dart' as utils;
@@ -78,6 +80,27 @@ class IEvent extends ICalendarElement with EventToDo {
       ..write(serializeEventToDo())
       ..writeln('END:VEVENT');
     return out.toString();
+  }
+
+  @override
+  void deserialize(ICalStructure structure) {
+    super.deserialize(structure);
+    start = _parseDate(structure["DTSTART"]);
+    end = _parseDate(structure["DTEND"]);
+    // TODO support duration
+    transparency = structure["TRANSP"] != null
+      ? ITimeTransparency._(structure["TRANSP"].value)
+        : null;
+    status = structure["STATUS"] != null
+      ? IEventStatus._(structure["STATUS"].value)
+        : null;
+    // TODO support missing event to do;
+  }
+
+  DateTime _parseDate(ICalRow row) {
+    if(row == null || row.value == null) return null;
+    // TODO: add TZID support
+    return DateTime.parse(row.value);
   }
 }
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:ical/serializer.dart';
+import 'package:ical/src/structure.dart';
+
+const _rowRegex = r"""^([\w-]+);?([\w-]+="[^"]*"|.*?):(.*)$""";
+const _middleRegex = r"""(?<key>[^=;]+)=(?<value>[^;]+)""";
+
+class ICalParser {
+  List<ICalRow> parseText(String text) {
+    // unfold strings
+    text = text.replaceAll("\r\n", "\n").replaceAll("\n ", "");
+    return LineSplitter()
+        .convert(text)
+        .map(_parseLine)
+        .where((element) => element != null)
+        .toList();
+  }
+
+  ICalRow _parseLine(String line) {
+    final regex = RegExp(_rowRegex);
+    final match = regex.firstMatch(line);
+    if(match == null) return null;
+    final String key = match.group(1);
+    final String middle = match.group(2);
+    final String value = match.group(3);
+    return ICalRow(key, value, properties: _parseMiddlePart(middle));
+  }
+
+  Map<String, String> _parseMiddlePart(String middle) {
+    final matches = RegExp(_middleRegex).allMatches(middle);
+    final entries = matches
+        .map((match) => MapEntry(match.namedGroup("key"), match.namedGroup("value")));
+    return Map.fromEntries(entries);
+  }
+  
+  ICalendar parseCalender(String text) {
+    final rows = parseText(text);
+
+  }
+}

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:ical/serializer.dart';
 import 'package:ical/src/structure.dart';
+import 'package:ical/src/utils.dart';
 
 const _rowRegex = r"""^([\w-]+);?([\w-]+="[^"]*"|.*?):(.*)$""";
 const _middleRegex = r"""(?<key>[^=;]+)=(?<value>[^;]+)""";
@@ -23,19 +24,19 @@ class ICalParser {
     if(match == null) return null;
     final String key = match.group(1);
     final String middle = match.group(2);
-    final String value = match.group(3);
+    final String value = unescapeValue(match.group(3));
     return ICalRow(key, value, properties: _parseMiddlePart(middle));
   }
 
   Map<String, String> _parseMiddlePart(String middle) {
     final matches = RegExp(_middleRegex).allMatches(middle);
     final entries = matches
-        .map((match) => MapEntry(match.namedGroup("key"), match.namedGroup("value")));
+        .map((match) => MapEntry(match.namedGroup("key"), unescapeValue(match.namedGroup("value"))));
     return Map.fromEntries(entries);
   }
   
   ICalendar parseCalender(String text) {
     final rows = parseText(text);
-
+    return ICalendar()..deserialize(ICalStructure.fromRows(rows));
   }
 }

--- a/lib/src/structure.dart
+++ b/lib/src/structure.dart
@@ -1,0 +1,42 @@
+class ICalStructure {
+  final String type;
+  final List<ICalRow> rows;
+  final List<ICalStructure> children;
+
+  ICalRow operator [](String key) {
+    return rows.firstWhere((row) => row.key == key, orElse: () => null);
+  }
+
+  const ICalStructure(this.type, this.rows, this.children);
+
+  factory ICalStructure.fromRows(List<ICalRow> rows) {
+    final beginRow = rows.removeAt(0);
+    if(beginRow == null) throw Exception("No begin row found");
+    final type = beginRow.value;
+    final List<ICalStructure> children = [];
+
+    var beginIndex = rows.indexWhere((element) => element.key == "BEGIN");
+    while(beginIndex != -1) {
+      final subType = rows[beginIndex].value;
+      final endIndex = rows.indexWhere((element) => element.key == "END" && element.value == subType) + 1;
+      if(endIndex == 0) throw Exception("No END row found for type $subType");
+      final subStructure = rows.getRange(beginIndex, endIndex);
+      children.add(ICalStructure.fromRows(subStructure.toList()));
+      rows.removeRange(beginIndex, endIndex);
+      beginIndex = rows.indexWhere((element) => element.key == "BEGIN");
+    }
+    // remove END row
+    // TODO check if end row is valid
+    final endRow = rows.removeLast();
+    if(endRow.key != "END" || endRow.value != type) throw Exception("Invalid END row");
+    return ICalStructure(type, rows, children);
+  }
+}
+
+class ICalRow {
+  final String key;
+  final String value;
+  final Map<String, String> properties;
+
+  const ICalRow(this.key, this.value, {this.properties = const {}});
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -25,3 +25,10 @@ String escapeValue(String val) => val
     .replaceAll('\t', '\\t')
     .replaceAll(',', '\\,')
     .replaceAll(';', '\\;');
+
+String unescapeValue(String val) => val
+    .replaceAll('\\\\', '\\')
+    .replaceAll('\\n', '\n')
+    .replaceAll('\\t', '\t')
+    .replaceAll('\\,', ',')
+    .replaceAll('\\;', ';');

--- a/test/parser.dart
+++ b/test/parser.dart
@@ -1,0 +1,44 @@
+import 'package:ical/src/calendar.dart';
+import 'package:ical/src/parser.dart';
+import 'package:test/test.dart';
+
+main() {
+  group('Parser', () {
+    ICalParser parser;
+    setUp(() {
+      parser = ICalParser();
+    });
+    test('parse single row', () {
+      const withMiddle = "DTSTART;VALUE=DATE:20200908";
+      const withoutMiddle = "CREATED:20200827T080438Z";
+
+      var result = parser.parseText(withMiddle);
+      var row = result.firstWhere((element) => element.key == "DTSTART");
+      expect(row?.value, "20200908");
+      expect(row?.properties["VALUE"], "DATE");
+
+      result = parser.parseText(withoutMiddle);
+      row = result.firstWhere((element) => element.key == "CREATED");
+      expect(row?.value, "20200827T080438Z");
+      expect(row?.properties?.length, 0);
+    });
+
+    test('parse multiple rows', () {
+      const testIcs = """CREATED:20200827T080438Z
+DTSTAMP:20200827T080438Z
+LAST-MODIFIED:20200827T080438Z
+DTSTART;VALUE=DATE:20200907
+DTEND;VALUE=DATE:20200908""";
+      final result = parser.parseText(testIcs);
+      expect(result.length, 5);
+      expect(result.map((e) => e.key), ["CREATED", "DTSTAMP", "LAST-MODIFIED", "DTSTART", "DTEND"]);
+    });
+
+    test('parse folded row', () {
+      const foldedRow = """TEST:testtesttesttesttesttest
+ testtest""";
+      final row = parser.parseText(foldedRow).firstWhere((element) => element.key == "TEST");
+      expect(row?.value, "testtesttesttesttesttesttesttest");
+    });
+  });
+}

--- a/test/parser.dart
+++ b/test/parser.dart
@@ -34,11 +34,48 @@ DTEND;VALUE=DATE:20200908""";
       expect(result.map((e) => e.key), ["CREATED", "DTSTAMP", "LAST-MODIFIED", "DTSTART", "DTEND"]);
     });
 
-    test('parse folded row', () {
+    test('parse calendar', () {
       const foldedRow = """TEST:testtesttesttesttesttest
  testtest""";
       final row = parser.parseText(foldedRow).firstWhere((element) => element.key == "TEST");
       expect(row?.value, "testtesttesttesttesttesttesttest");
+    });
+
+    test('parse example ICalStructure', () {
+      const testIcs = """BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+SUMMARY:Access-A-Ride Pickup
+DTSTART;TZID=America/New_York:20130802T103400
+DTEND;TZID=America/New_York:20130802T110400
+LOCATION:1000 Broadway Ave.\, Brooklyn
+DESCRIPTION: Access-A-Ride trip to 900 Jay St.\, Brooklyn
+STATUS:CONFIRMED
+SEQUENCE:3
+BEGIN:VALARM
+TRIGGER:-PT10M
+DESCRIPTION:Pickup Reminder
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Access-A-Ride Pickup
+DTSTART;TZID=America/New_York:20130802T200000
+DTEND;TZID=America/New_York:20130802T203000
+LOCATION:900 Jay St.\, Brooklyn
+DESCRIPTION: Access-A-Ride trip to 1000 Broadway Ave.\, Brooklyn
+STATUS:CONFIRMED
+SEQUENCE:3
+BEGIN:VALARM
+TRIGGER:-PT10M
+DESCRIPTION:Pickup Reminder
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR""";
+      final result = parser.parseCalender(testIcs);
+      expect(result.events.length, 2);
     });
   });
 }

--- a/test/structure.dart
+++ b/test/structure.dart
@@ -1,0 +1,53 @@
+import 'package:ical/src/calendar.dart';
+import 'package:ical/src/parser.dart';
+import 'package:ical/src/structure.dart';
+import 'package:test/test.dart';
+
+main() {
+  group('Structure', () {
+    ICalParser parser;
+    setUp(() {
+      parser = ICalParser();
+    });
+
+    test('parse example ICalStructure', () {
+      const testIcs = """BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+SUMMARY:Access-A-Ride Pickup
+DTSTART;TZID=America/New_York:20130802T103400
+DTEND;TZID=America/New_York:20130802T110400
+LOCATION:1000 Broadway Ave.\, Brooklyn
+DESCRIPTION: Access-A-Ride trip to 900 Jay St.\, Brooklyn
+STATUS:CONFIRMED
+SEQUENCE:3
+BEGIN:VALARM
+TRIGGER:-PT10M
+DESCRIPTION:Pickup Reminder
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Access-A-Ride Pickup
+DTSTART;TZID=America/New_York:20130802T200000
+DTEND;TZID=America/New_York:20130802T203000
+LOCATION:900 Jay St.\, Brooklyn
+DESCRIPTION: Access-A-Ride trip to 1000 Broadway Ave.\, Brooklyn
+STATUS:CONFIRMED
+SEQUENCE:3
+BEGIN:VALARM
+TRIGGER:-PT10M
+DESCRIPTION:Pickup Reminder
+ACTION:DISPLAY
+END:VALARM
+END:VEVENT
+END:VCALENDAR""";
+      final result = parser.parseText(testIcs);
+      final structure = ICalStructure.fromRows(result);
+      expect(structure.type, "VCALENDAR");
+      expect(structure.children.length, 2);
+      expect(structure["VERSION"]?.value, "2.0");
+    });
+  });
+}


### PR DESCRIPTION
This PR adds some basic deserialization features for parsing iCal-Files. The example implementation only contains a subset of the `VEVENT` element. This implementation could be extended in the future. I currently don't have time to implement the deserialization for all elements myself. Maybe somebody else can do it.