### PR TITLE
Fixed line delimiter and added lines folding for event description 

### DIFF
--- a/lib/src/abstract.dart
+++ b/lib/src/abstract.dart
@@ -130,6 +130,28 @@ abstract class ICalendarElement extends AbstractSerializer {
     this.rrule,
   });
 
+  String ical_split(String value, {String preamble = "DESCRIPTION:"}) {
+    const CONTENT_LINES_MAX_OCTETS = 75;
+
+    final lines = [];
+    var v = value;
+
+    final LINE_LENGTH_WITHOUT_PREAMBLE =
+        CONTENT_LINES_MAX_OCTETS - preamble.length;
+
+    if (v.length > LINE_LENGTH_WITHOUT_PREAMBLE) {
+      lines.add(v.substring(0, LINE_LENGTH_WITHOUT_PREAMBLE));
+      v = v.substring(LINE_LENGTH_WITHOUT_PREAMBLE);
+    }
+
+    while (v.length > CONTENT_LINES_MAX_OCTETS) {
+      lines.add(v.substring(0, CONTENT_LINES_MAX_OCTETS));
+      v = v.substring(CONTENT_LINES_MAX_OCTETS);
+    }
+    if (v.isNotEmpty) lines.add(v);
+    return lines.join("$CLRF_LINE_DELIMITER\t");
+  }
+
   String serialize() {
     var out = StringBuffer();
 
@@ -150,7 +172,8 @@ abstract class ICalendarElement extends AbstractSerializer {
     if (classification != null)
       out.write('CLASS:$classification$CLRF_LINE_DELIMITER');
     if (description != null)
-      out.write('DESCRIPTION:${escapeValue(description)}$CLRF_LINE_DELIMITER');
+      out.write(
+          'DESCRIPTION:${ical_split(escapeValue(description))}$CLRF_LINE_DELIMITER');
     if (rrule != null) out.write(rrule.serialize());
 
     return out.toString();

--- a/lib/src/abstract.dart
+++ b/lib/src/abstract.dart
@@ -5,6 +5,8 @@ import 'utils.dart' as utils;
 import 'subcomponents.dart';
 import 'package:nanoid/nanoid.dart';
 
+const CLRF_LINE_DELIMITER = "\r\n";
+
 abstract class AbstractSerializer {
   String serialize();
 }
@@ -83,7 +85,7 @@ class IRecurrenceRule {
     if (weekday > 0 && weekday < 8) {
       out.write(';WKST=${weekdays[weekday - 1]}');
     }
-    out.writeln('');
+    out.write(CLRF_LINE_DELIMITER);
     return out.toString();
   }
 }
@@ -100,7 +102,7 @@ class IOrganizer {
     if (email == null) {
       return '';
     }
-    out.writeln(':mailto:$email');
+    out.write(':mailto:$email$CLRF_LINE_DELIMITER');
     return out.toString();
   }
 }
@@ -133,18 +135,22 @@ abstract class ICalendarElement extends AbstractSerializer {
 
     uid ??= nanoid(32);
 
-    out.writeln('UID:$uid');
+    out.write('UID:$uid$CLRF_LINE_DELIMITER');
 
     if (categories != null) {
-      out.writeln('CATEGORIES:${categories.map(escapeValue).join(',')}');
+      out.write(
+          'CATEGORIES:${categories.map(escapeValue).join(',')}$CLRF_LINE_DELIMITER');
     }
 
-    if (comment != null) out.writeln('COMMENT:${escapeValue(comment)}');
-    if (summary != null) out.writeln('SUMMARY:${escapeValue(summary)}');
-    if (url != null) out.writeln('URL:${url}');
-    if (classification != null) out.writeln('CLASS:$classification');
+    if (comment != null)
+      out.write('COMMENT:${escapeValue(comment)}$CLRF_LINE_DELIMITER');
+    if (summary != null)
+      out.write('SUMMARY:${escapeValue(summary)}$CLRF_LINE_DELIMITER');
+    if (url != null) out.write('URL:${url}$CLRF_LINE_DELIMITER');
+    if (classification != null)
+      out.write('CLASS:$classification$CLRF_LINE_DELIMITER');
     if (description != null)
-      out.writeln('DESCRIPTION:${escapeValue(description)}');
+      out.write('DESCRIPTION:${escapeValue(description)}$CLRF_LINE_DELIMITER');
     if (rrule != null) out.write(rrule.serialize());
 
     return out.toString();
@@ -165,14 +171,17 @@ mixin EventToDo {
 
   String serializeEventToDo() {
     var out = StringBuffer();
-    if (location != null) out.writeln('LOCATION:${escapeValue(location)}');
-    if (lat != null && lng != null) out.writeln('GEO:$lat;$lng');
+    if (location != null)
+      out.write('LOCATION:${escapeValue(location)}$CLRF_LINE_DELIMITER');
+    if (lat != null && lng != null)
+      out.write('GEO:$lat;$lng$CLRF_LINE_DELIMITER');
     if (resources != null) {
-      out.writeln('RESOURCES:${resources.map(escapeValue).join(',')}');
+      out.write(
+          'RESOURCES:${resources.map(escapeValue).join(',')}$CLRF_LINE_DELIMITER');
     }
     if (priority != null) {
       priority = (priority >= 0 && priority <= 9) ? priority : 0;
-      out.writeln('PRIORITY:$priority');
+      out.write('PRIORITY:$priority$CLRF_LINE_DELIMITER');
     }
     if (alarm != null) out.write(alarm.serialize());
 

--- a/lib/src/abstract.dart
+++ b/lib/src/abstract.dart
@@ -132,6 +132,7 @@ abstract class ICalendarElement extends AbstractSerializer {
 
   String ical_split(String value, {String preamble = "DESCRIPTION:"}) {
     const CONTENT_LINES_MAX_OCTETS = 75;
+    const CONTENT_LINES_MAX_OCTETS_WITHOUT_SPACE = CONTENT_LINES_MAX_OCTETS - 1;
 
     final lines = [];
     var v = value;
@@ -144,9 +145,9 @@ abstract class ICalendarElement extends AbstractSerializer {
       v = v.substring(LINE_LENGTH_WITHOUT_PREAMBLE);
     }
 
-    while (v.length > CONTENT_LINES_MAX_OCTETS) {
-      lines.add(v.substring(0, CONTENT_LINES_MAX_OCTETS));
-      v = v.substring(CONTENT_LINES_MAX_OCTETS);
+    while (v.length > CONTENT_LINES_MAX_OCTETS_WITHOUT_SPACE) {
+      lines.add(v.substring(0, CONTENT_LINES_MAX_OCTETS_WITHOUT_SPACE));
+      v = v.substring(CONTENT_LINES_MAX_OCTETS_WITHOUT_SPACE);
     }
     if (v.isNotEmpty) lines.add(v);
     return lines.join("$CLRF_LINE_DELIMITER\t");

--- a/lib/src/abstract.dart
+++ b/lib/src/abstract.dart
@@ -130,7 +130,7 @@ abstract class ICalendarElement extends AbstractSerializer {
     this.rrule,
   });
 
-  String ical_split(String value, {String preamble = "DESCRIPTION:"}) {
+  String _foldLiens(String value, {String preamble = "DESCRIPTION:"}) {
     const CONTENT_LINES_MAX_OCTETS = 75;
     const CONTENT_LINES_MAX_OCTETS_WITHOUT_SPACE = CONTENT_LINES_MAX_OCTETS - 1;
 
@@ -150,7 +150,10 @@ abstract class ICalendarElement extends AbstractSerializer {
       v = v.substring(CONTENT_LINES_MAX_OCTETS_WITHOUT_SPACE);
     }
     if (v.isNotEmpty) lines.add(v);
-    return lines.join("$CLRF_LINE_DELIMITER\t");
+
+    return lines.length == 1
+        ? lines.first
+        : lines.join("$CLRF_LINE_DELIMITER\t");
   }
 
   String serialize() {
@@ -174,7 +177,7 @@ abstract class ICalendarElement extends AbstractSerializer {
       out.write('CLASS:$classification$CLRF_LINE_DELIMITER');
     if (description != null)
       out.write(
-          'DESCRIPTION:${ical_split(escapeValue(description))}$CLRF_LINE_DELIMITER');
+          'DESCRIPTION:${_foldLiens(escapeValue(description))}$CLRF_LINE_DELIMITER');
     if (rrule != null) out.write(rrule.serialize());
 
     return out.toString();

--- a/lib/src/abstract.dart
+++ b/lib/src/abstract.dart
@@ -134,6 +134,8 @@ abstract class ICalendarElement extends AbstractSerializer {
     const CONTENT_LINES_MAX_OCTETS = 75;
     const CONTENT_LINES_MAX_OCTETS_WITHOUT_SPACE = CONTENT_LINES_MAX_OCTETS - 1;
 
+    if (value == null || value.isEmpty) return '';
+
     final lines = [];
     var v = value;
 

--- a/lib/src/calendar.dart
+++ b/lib/src/calendar.dart
@@ -21,20 +21,20 @@ class ICalendar extends AbstractSerializer {
   @override
   String serialize() {
     var out = StringBuffer()
-      ..writeln('BEGIN:VCALENDAR')
-      ..writeln('VERSION:2.0')
-      ..writeln('PRODID://${company}//${product}//${lang}');
+      ..write('BEGIN:VCALENDAR$CLRF_LINE_DELIMITER')
+      ..write('VERSION:2.0$CLRF_LINE_DELIMITER')
+      ..write('PRODID://${company}//${product}//${lang}$CLRF_LINE_DELIMITER');
 
     if (refreshInterval != null) {
-      out.writeln(
-          'REFRESH-INTERVAL;VALUE=DURATION:${utils.formatDuration(refreshInterval)}');
+      out.write(
+          'REFRESH-INTERVAL;VALUE=DURATION:${utils.formatDuration(refreshInterval)}$CLRF_LINE_DELIMITER');
     }
 
     for (ICalendarElement element in _elements) {
       out.write(element.serialize());
     }
 
-    out.writeln('END:VCALENDAR');
+    out.write('END:VCALENDAR$CLRF_LINE_DELIMITER');
     return out.toString();
   }
 }

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -53,30 +53,33 @@ class IEvent extends ICalendarElement with EventToDo {
   String serialize() {
     super.serialize();
     var out = StringBuffer()
-      ..writeln('BEGIN:VEVENT')
-      ..writeln('DTSTAMP:${utils.formatDateTime(start ?? DateTime.now())}');
+      ..write('BEGIN:VEVENT$CLRF_LINE_DELIMITER')
+      ..write(
+          'DTSTAMP:${utils.formatDateTime(start ?? DateTime.now())}$CLRF_LINE_DELIMITER');
 
     if ((end == null && duration == null)) {
-      out.writeln('DTSTART;VALUE=DATE:${utils.formatDate(start)}');
+      out.write(
+          'DTSTART;VALUE=DATE:${utils.formatDate(start)}$CLRF_LINE_DELIMITER');
     } else {
-      out.writeln('DTSTART:${utils.formatDateTime(start)}');
+      out.write('DTSTART:${utils.formatDateTime(start)}$CLRF_LINE_DELIMITER');
     }
 
     if (end != null) {
-      out.writeln('DTEND:${utils.formatDateTime(end)}');
+      out.write('DTEND:${utils.formatDateTime(end)}$CLRF_LINE_DELIMITER');
     }
     if (duration != null) {
-      out.writeln('DURATION:${utils.formatDuration(duration)}');
+      out.write(
+          'DURATION:${utils.formatDuration(duration)}$CLRF_LINE_DELIMITER');
     }
     if (transparency != null) {
-      out.writeln('TRANSP:$transparency');
+      out.write('TRANSP:$transparency$CLRF_LINE_DELIMITER');
     }
 
     out
-      ..writeln('STATUS:$status')
+      ..write('STATUS:$status$CLRF_LINE_DELIMITER')
       ..write(super.serialize())
       ..write(serializeEventToDo())
-      ..writeln('END:VEVENT');
+      ..write('END:VEVENT$CLRF_LINE_DELIMITER');
     return out.toString();
   }
 }

--- a/lib/src/journal.dart
+++ b/lib/src/journal.dart
@@ -42,12 +42,14 @@ class IJournal extends ICalendarElement {
   @override
   String serialize() {
     var out = StringBuffer()
-      ..writeln('BEGIN:VJOURNAL')
-      ..writeln('DTSTAMP:${utils.formatDateTime(start ?? DateTime.now())}')
-      ..writeln('DTSTART;VALUE=DATE:${utils.formatDate(start)}')
-      ..writeln('STATUS:$status')
+      ..write('BEGIN:VJOURNAL$CLRF_LINE_DELIMITER')
+      ..write(
+          'DTSTAMP:${utils.formatDateTime(start ?? DateTime.now())}$CLRF_LINE_DELIMITER')
+      ..write(
+          'DTSTART;VALUE=DATE:${utils.formatDate(start)}$CLRF_LINE_DELIMITER')
+      ..write('STATUS:$status$CLRF_LINE_DELIMITER')
       ..write(super.serialize())
-      ..writeln('END:VJOURNAL');
+      ..write('END:VJOURNAL$CLRF_LINE_DELIMITER');
     return out.toString();
   }
 }

--- a/lib/src/subcomponents.dart
+++ b/lib/src/subcomponents.dart
@@ -45,29 +45,33 @@ class IAlarm extends AbstractSerializer {
 
   @override
   String serialize() {
-    var out = StringBuffer()..writeln('BEGIN:VALARM')..writeln('ACTION:$type');
+    var out = StringBuffer()
+      ..write('BEGIN:VALARM$CLRF_LINE_DELIMITER')
+      ..write('ACTION:$type$CLRF_LINE_DELIMITER');
     switch (type) {
       case IAlarmType.DISPLAY:
-        out.writeln(_serializeDescription());
+        out.write(_serializeDescription() + CLRF_LINE_DELIMITER);
         break;
       case IAlarmType.EMAIL:
-        out.writeln(_serializeDescription());
-        out.writeln('SUMMARY:${escapeValue(summary)}');
+        out.write(_serializeDescription() + CLRF_LINE_DELIMITER);
+        out.write('SUMMARY:${escapeValue(summary)}$CLRF_LINE_DELIMITER');
 
         // TODO ATTENDEE
         break;
     }
 
     if (repeat > 1) {
-      out.writeln('REPEAT:$repeat');
-      out.writeln('DURATION:${utils.formatDuration(duration)}');
+      out.write('REPEAT:$repeat$CLRF_LINE_DELIMITER');
+      out.write(
+          'DURATION:${utils.formatDuration(duration)}$CLRF_LINE_DELIMITER');
     }
 
     if (trigger != null) {
-      out.writeln('TRIGGER;VALUE=DATE-TIME:${utils.formatDateTime(trigger)}');
+      out.write(
+          'TRIGGER;VALUE=DATE-TIME:${utils.formatDateTime(trigger)}$CLRF_LINE_DELIMITER');
     }
 
-    out.writeln('END:VALARM');
+    out.write('END:VALARM$CLRF_LINE_DELIMITER');
     return out.toString();
   }
 }

--- a/lib/src/todo.dart
+++ b/lib/src/todo.dart
@@ -74,21 +74,26 @@ class ITodo extends ICalendarElement with EventToDo {
   @override
   String serialize() {
     var out = StringBuffer()
-      ..writeln('BEGIN:VTODO')
-      ..writeln('DTSTAMP:${utils.formatDateTime(start ?? DateTime.now())}')
-      ..writeln('DTSTART;VALUE=DATE:${utils.formatDate(start)}')
-      ..writeln('STATUS:$status');
+      ..write('BEGIN:VTODO$CLRF_LINE_DELIMITER')
+      ..write(
+          'DTSTAMP:${utils.formatDateTime(start ?? DateTime.now())}$CLRF_LINE_DELIMITER')
+      ..write(
+          'DTSTART;VALUE=DATE:${utils.formatDate(start)}$CLRF_LINE_DELIMITER')
+      ..write('STATUS:$status$CLRF_LINE_DELIMITER');
 
-    if (due != null) out.writeln('DUE;VALUE=DATE:${utils.formatDate(due)}');
+    if (due != null)
+      out.write('DUE;VALUE=DATE:${utils.formatDate(due)}$CLRF_LINE_DELIMITER');
     if (duration != null) {
-      out.writeln('DURATION:${utils.formatDuration(duration)}');
+      out.write(
+          'DURATION:${utils.formatDuration(duration)}$CLRF_LINE_DELIMITER');
     }
 
-    if (complete != null) out.writeln('PERCENT-COMPLETE:$_complete');
+    if (complete != null)
+      out.write('PERCENT-COMPLETE:$_complete$CLRF_LINE_DELIMITER');
 
     out.write(super.serialize());
     out.write(serializeEventToDo());
-    out.writeln('END:VTODO');
+    out.write('END:VTODO$CLRF_LINE_DELIMITER');
     return out.toString();
   }
 }


### PR DESCRIPTION
Before the changes I used the [iCalendar Validator](https://icalendar.org/validator.html) to validate an ics file generated by this plugin and I got an error that the liens are not delimited by CLRF delimiter and a warning that the description was longer than 75 octet so I made the required changes to fix the issues