### PR TITLE
Add a getter for _elements.

### DIFF
--- a/lib/src/calendar.dart
+++ b/lib/src/calendar.dart
@@ -8,6 +8,8 @@ class ICalendar extends AbstractSerializer {
   String lang;
   Duration refreshInterval;
 
+  List<ICalendarElement> get elements => _elements;
+
   ICalendar({
     this.company = 'dartclub',
     this.product = 'ical/serializer',


### PR DESCRIPTION
Hi,

This is my first ever PR (+ I just started developping with Flutter), so if I've done something wrong, just say it, and I'll do my best.

I'm trying to deserialize an ical. To do so, I've chosen to use your library to extend Icalendar and Ievent.
I'm close to the end, but there's no getter for _elements in Icalendar.

If you want to see my work to deserialize the ical, I could make another PR when I'm done. It could help others.

Edit : Just saw there was another PR to deserialize, I'll give it a try

Thanks !