### PR TITLE
Update intl to 0.17

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
-  intl: ^0.16.0
+  intl: ^0.17.0
   nanoid: ^0.1.0
 
 dev_dependencies:


### PR DESCRIPTION
intl version uses null safety
There are already some packages using intl 0.17, if there is no version of ical using 0.17 then it is not possible to be used together with this packages.