### PR TITLE
Null safety migration

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,8 +2,7 @@ name: example
 environment:
   sdk: '>=2.1.0 <3.0.0'
 dependencies:
-  intl: ^0.15.7
-  nanoid: ^0.0.6
+  intl: ^0.17.0
+  nanoid: ^0.1.0
   ical:
     path: ..
-  

--- a/lib/src/abstract.dart
+++ b/lib/src/abstract.dart
@@ -44,8 +44,8 @@ class IRecurrenceFrequency {
 }
 
 class IRecurrenceRule {
-  IRecurrenceFrequency frequency = IRecurrenceFrequency.DAILY;
-  DateTime untilDate;
+  IRecurrenceFrequency? frequency = IRecurrenceFrequency.DAILY;
+  DateTime? untilDate;
   int count;
   int interval;
   int weekday;
@@ -72,7 +72,7 @@ class IRecurrenceRule {
     out..write('RRULE:FREQ=$frequency');
 
     if (untilDate != null) {
-      out.write(';UNTIL=${utils.formatDateTime(untilDate)}');
+      out.write(';UNTIL=${utils.formatDateTime(untilDate!)}');
     }
     if (count > 0) {
       out.write(';COUNT=$count');
@@ -89,13 +89,13 @@ class IRecurrenceRule {
 }
 
 class IOrganizer {
-  String name;
-  String email;
+  String? name;
+  String? email;
   IOrganizer({this.name, this.email});
   String serializeOrganizer() {
     var out = StringBuffer()..write('ORGANIZER');
     if (name != null) {
-      out.write(';CN=${escapeValue(name)}');
+      out.write(';CN=${escapeValue(name!)}');
     }
     if (email == null) {
       return '';
@@ -106,15 +106,15 @@ class IOrganizer {
 }
 
 abstract class ICalendarElement extends AbstractSerializer {
-  IOrganizer organizer;
-  String uid;
-  String summary;
-  String description;
-  List<String> categories;
-  String url;
-  IClass classification;
-  String comment;
-  IRecurrenceRule rrule;
+  IOrganizer? organizer;
+  String? uid;
+  String? summary;
+  String? description;
+  List<String>? categories;
+  String? url;
+  IClass? classification;
+  String? comment;
+  IRecurrenceRule? rrule;
 
   ICalendarElement({
     this.organizer,
@@ -136,16 +136,16 @@ abstract class ICalendarElement extends AbstractSerializer {
     out.writeln('UID:$uid');
 
     if (categories != null) {
-      out.writeln('CATEGORIES:${categories.map(escapeValue).join(',')}');
+      out.writeln('CATEGORIES:${categories!.map(escapeValue).join(',')}');
     }
 
-    if (comment != null) out.writeln('COMMENT:${escapeValue(comment)}');
-    if (summary != null) out.writeln('SUMMARY:${escapeValue(summary)}');
+    if (comment != null) out.writeln('COMMENT:${escapeValue(comment!)}');
+    if (summary != null) out.writeln('SUMMARY:${escapeValue(summary!)}');
     if (url != null) out.writeln('URL:${url}');
     if (classification != null) out.writeln('CLASS:$classification');
     if (description != null)
-      out.writeln('DESCRIPTION:${escapeValue(description)}');
-    if (rrule != null) out.write(rrule.serialize());
+      out.writeln('DESCRIPTION:${escapeValue(description!)}');
+    if (rrule != null) out.write(rrule!.serialize());
 
     return out.toString();
   }
@@ -156,25 +156,25 @@ abstract class ICalendarElement extends AbstractSerializer {
 // Component Properties for Event + To-Do
 
 mixin EventToDo {
-  String location;
-  double lat;
-  double lng;
-  int priority;
-  List<String> resources;
-  IAlarm alarm;
+  String? location;
+  double? lat;
+  double? lng;
+  int? priority;
+  List<String>? resources;
+  IAlarm? alarm;
 
   String serializeEventToDo() {
     var out = StringBuffer();
-    if (location != null) out.writeln('LOCATION:${escapeValue(location)}');
+    if (location != null) out.writeln('LOCATION:${escapeValue(location!)}');
     if (lat != null && lng != null) out.writeln('GEO:$lat;$lng');
     if (resources != null) {
-      out.writeln('RESOURCES:${resources.map(escapeValue).join(',')}');
+      out.writeln('RESOURCES:${resources!.map(escapeValue).join(',')}');
     }
     if (priority != null) {
-      priority = (priority >= 0 && priority <= 9) ? priority : 0;
+      priority = (priority! >= 0 && priority! <= 9) ? priority : 0;
       out.writeln('PRIORITY:$priority');
     }
-    if (alarm != null) out.write(alarm.serialize());
+    if (alarm != null) out.write(alarm!.serialize());
 
     return out.toString();
   }

--- a/lib/src/calendar.dart
+++ b/lib/src/calendar.dart
@@ -6,7 +6,7 @@ class ICalendar extends AbstractSerializer {
   String company;
   String product;
   String lang;
-  Duration refreshInterval;
+  Duration? refreshInterval;
 
   List<ICalendarElement> get elements => _elements;
 
@@ -29,7 +29,7 @@ class ICalendar extends AbstractSerializer {
 
     if (refreshInterval != null) {
       out.writeln(
-          'REFRESH-INTERVAL;VALUE=DURATION:${utils.formatDuration(refreshInterval)}');
+          'REFRESH-INTERVAL;VALUE=DURATION:${utils.formatDuration(refreshInterval!)}');
     }
 
     for (ICalendarElement element in _elements) {

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -3,33 +3,33 @@ import 'subcomponents.dart';
 import 'utils.dart' as utils;
 
 class IEvent extends ICalendarElement with EventToDo {
-  IEventStatus status = IEventStatus.CONFIRMED;
-  DateTime start;
-  DateTime end;
-  Duration duration;
-  ITimeTransparency transparency = ITimeTransparency.OPAQUE;
+  IEventStatus? status = IEventStatus.CONFIRMED;
+  DateTime? start;
+  DateTime? end;
+  Duration? duration;
+  ITimeTransparency? transparency = ITimeTransparency.OPAQUE;
 
-  String location;
-  double lat, lng;
-  List<String> resources;
-  IAlarm alarm;
-  IOrganizer organizer;
-  int priority;
+  String? location;
+  double? lat, lng;
+  List<String>? resources;
+  IAlarm? alarm;
+  IOrganizer? organizer;
+  int? priority;
 
   IEvent({
-    IOrganizer organizer,
-    String uid,
+    IOrganizer? organizer,
+    String? uid,
     this.status,
     this.start,
     this.end,
     this.duration,
-    String summary,
-    String description,
-    List<String> categories,
-    String url,
+    String? summary,
+    String? description,
+    List<String>? categories,
+    String? url,
     IClass classification = IClass.PRIVATE,
-    String comment,
-    IRecurrenceRule rrule,
+    String? comment,
+    IRecurrenceRule? rrule,
     this.transparency,
     this.location,
     this.lat,
@@ -57,16 +57,16 @@ class IEvent extends ICalendarElement with EventToDo {
       ..writeln('DTSTAMP:${utils.formatDateTime(start ?? DateTime.now())}');
 
     if ((end == null && duration == null)) {
-      out.writeln('DTSTART;VALUE=DATE:${utils.formatDate(start)}');
+      out.writeln('DTSTART;VALUE=DATE:${utils.formatDate(start!)}');
     } else {
-      out.writeln('DTSTART:${utils.formatDateTime(start)}');
+      out.writeln('DTSTART:${utils.formatDateTime(start!)}');
     }
 
     if (end != null) {
-      out.writeln('DTEND:${utils.formatDateTime(end)}');
+      out.writeln('DTEND:${utils.formatDateTime(end!)}');
     }
     if (duration != null) {
-      out.writeln('DURATION:${utils.formatDuration(duration)}');
+      out.writeln('DURATION:${utils.formatDuration(duration!)}');
     }
     if (transparency != null) {
       out.writeln('TRANSP:$transparency');

--- a/lib/src/journal.dart
+++ b/lib/src/journal.dart
@@ -13,20 +13,20 @@ class IJournalStatus {
 }
 
 class IJournal extends ICalendarElement {
-  IJournalStatus status;
-  DateTime start;
+  IJournalStatus? status;
+  DateTime? start;
   IJournal({
     this.status,
     this.start,
-    IOrganizer organizer,
-    String uid,
-    String summary,
-    String description,
-    List<String> categories,
-    String url,
+    IOrganizer? organizer,
+    String? uid,
+    String? summary,
+    String? description,
+    List<String>? categories,
+    String? url,
     IClass classification = IClass.PRIVATE,
-    String comment,
-    IRecurrenceRule rrule,
+    String? comment,
+    IRecurrenceRule? rrule,
   }) : super(
           organizer: organizer,
           uid: uid,
@@ -44,7 +44,7 @@ class IJournal extends ICalendarElement {
     var out = StringBuffer()
       ..writeln('BEGIN:VJOURNAL')
       ..writeln('DTSTAMP:${utils.formatDateTime(start ?? DateTime.now())}')
-      ..writeln('DTSTART;VALUE=DATE:${utils.formatDate(start)}')
+      ..writeln('DTSTART;VALUE=DATE:${utils.formatDate(start!)}')
       ..writeln('STATUS:$status')
       ..write(super.serialize())
       ..writeln('END:VJOURNAL');

--- a/lib/src/subcomponents.dart
+++ b/lib/src/subcomponents.dart
@@ -18,8 +18,8 @@ class IAlarm extends AbstractSerializer {
   IAlarmType type;
   Duration duration;
   int repeat;
-  DateTime trigger;
-  String description, summary;
+  DateTime? trigger;
+  String? description, summary;
 
   IAlarm.display({
     this.duration = const Duration(minutes: 15),
@@ -41,7 +41,7 @@ class IAlarm extends AbstractSerializer {
   //    this.summary})
   //s    : type = AlarmType.EMAIL;
 
-  String _serializeDescription() => 'DESCRIPTION:${escapeValue(description)}';
+  String _serializeDescription() => 'DESCRIPTION:${escapeValue(description!)}';
 
   @override
   String serialize() {
@@ -52,7 +52,7 @@ class IAlarm extends AbstractSerializer {
         break;
       case IAlarmType.EMAIL:
         out.writeln(_serializeDescription());
-        out.writeln('SUMMARY:${escapeValue(summary)}');
+        out.writeln('SUMMARY:${escapeValue(summary!)}');
 
         // TODO ATTENDEE
         break;
@@ -64,7 +64,7 @@ class IAlarm extends AbstractSerializer {
     }
 
     if (trigger != null) {
-      out.writeln('TRIGGER;VALUE=DATE-TIME:${utils.formatDateTime(trigger)}');
+      out.writeln('TRIGGER;VALUE=DATE-TIME:${utils.formatDateTime(trigger!)}');
     }
 
     out.writeln('END:VALARM');

--- a/lib/src/todo.dart
+++ b/lib/src/todo.dart
@@ -16,29 +16,29 @@ class ITodoStatus {
 
 class ITodo extends ICalendarElement with EventToDo {
   ITodoStatus status;
-  DateTime completed;
-  DateTime due;
-  DateTime start;
-  Duration duration;
+  DateTime? completed;
+  DateTime? due;
+  DateTime? start;
+  Duration? duration;
 
-  String location;
-  double lat;
-  double lng;
-  List<String> resources;
-  IAlarm alarm;
-  int priority;
+  String? location;
+  double? lat;
+  double? lng;
+  List<String>? resources;
+  IAlarm? alarm;
+  int? priority;
 
-  int _complete;
+  late int _complete;
   set complete(int c) {
     assert(c >= 0 && c <= 100);
     _complete = c;
   }
 
-  get complete => _complete;
+  int get complete => _complete;
 
   ITodo({
-    IOrganizer organizer,
-    String uid,
+    IOrganizer? organizer,
+    String? uid,
     this.status = ITodoStatus.NEEDS_ACTION,
     this.start,
     this.due,
@@ -50,13 +50,13 @@ class ITodo extends ICalendarElement with EventToDo {
     this.alarm,
     int percentComplete = 0,
     this.priority = 0,
-    String summary,
-    String description,
-    List<String> categories,
-    String url,
+    String? summary,
+    String? description,
+    List<String>? categories,
+    String? url,
     IClass classification = IClass.PRIVATE,
-    String comment,
-    IRecurrenceRule rrule,
+    String? comment,
+    IRecurrenceRule? rrule,
   }) : super(
           organizer: organizer,
           uid: uid,
@@ -76,15 +76,15 @@ class ITodo extends ICalendarElement with EventToDo {
     var out = StringBuffer()
       ..writeln('BEGIN:VTODO')
       ..writeln('DTSTAMP:${utils.formatDateTime(start ?? DateTime.now())}')
-      ..writeln('DTSTART;VALUE=DATE:${utils.formatDate(start)}')
+      ..writeln('DTSTART;VALUE=DATE:${utils.formatDate(start!)}')
       ..writeln('STATUS:$status');
 
-    if (due != null) out.writeln('DUE;VALUE=DATE:${utils.formatDate(due)}');
+    if (due != null) out.writeln('DUE;VALUE=DATE:${utils.formatDate(due!)}');
     if (duration != null) {
-      out.writeln('DURATION:${utils.formatDuration(duration)}');
+      out.writeln('DURATION:${utils.formatDuration(duration!)}');
     }
 
-    if (complete != null) out.writeln('PERCENT-COMPLETE:$_complete');
+    out.writeln('PERCENT-COMPLETE:$_complete');
 
     out.write(super.serialize());
     out.write(serializeEventToDo());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,13 +6,13 @@ author: Lukas Himsel <lukas@himsel.me>
 homepage: https://github.com/dartclub/ical
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   intl: ^0.17.0
-  nanoid: ^0.1.0
+  nanoid: ^1.0.0
 
 dev_dependencies:
-  test: ^1.5.1+1
-  pedantic: ^1.8.0
+  test: ^1.16.8
+  pedantic: ^1.11.0
 

--- a/test/calendar.dart
+++ b/test/calendar.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 main() {
   group('Calendar', () {
-    ICalendar iCalendar;
+    late ICalendar iCalendar;
     setUp(() {
       iCalendar = ICalendar(
         company: 'Umbrella Inc.',

--- a/test/event.dart
+++ b/test/event.dart
@@ -5,7 +5,7 @@ import 'package:ical/src/abstract.dart';
 
 main() {
   group('Event', () {
-    IEvent e, e2;
+    late IEvent e, e2;
     setUp(() {
       e = IEvent(
         uid: 'lukas@himsel.me',

--- a/test/property.dart
+++ b/test/property.dart
@@ -3,15 +3,15 @@ import 'package:test/test.dart';
 
 class ElementTest extends ICalendarElement {
   ElementTest({
-    IOrganizer organizer,
-    String uid,
-    String summary,
-    String description,
-    List<String> categories,
-    String url,
-    IClass classification,
-    String comment,
-    IRecurrenceRule rrule,
+    IOrganizer? organizer,
+    String? uid,
+    String? summary,
+    String? description,
+    List<String>? categories,
+    String? url,
+    IClass? classification,
+    String? comment,
+    IRecurrenceRule? rrule,
   }) : super(
           organizer: organizer,
           uid: uid,
@@ -26,7 +26,7 @@ class ElementTest extends ICalendarElement {
 }
 
 main() {
-  ElementTest t1, t2;
+  late ElementTest t1, t2;
   group('test ElementTest', () {
     setUp(() {
       t1 = ElementTest();

--- a/test/subcomponents.dart
+++ b/test/subcomponents.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 main() {
   group('Alarm', () {
     group('Alarm.display', () {
-      IAlarm disp;
+      late IAlarm disp;
       setUp(() {
         disp = IAlarm.display(
           duration: Duration(minutes: 23),


### PR DESCRIPTION
I started using your `ical` package in my project last weekend. When I was running my tests, I hit the issue that this package is not null-safe yet, and I figured I would try to help.

This PR contains the changes suggested when running `dart migrate`. Essentially, 
 - updating the dependencies to to null-safety versions
 - making some types nullable
 - adding null assertions when accessing nullable types

There are some additional instances where the `late` keyword was needed, too.

I have just started looking at `dart`, and I essentially followed the automatic migration process. After doing that, I manually run the tests in this module. `subcomponents` and `utils` failed, but they were failing already before the migration (in the case of `utils`, it seems to be a timezone issue. In the case of subcomponents, the error is *Bad state: Can't call test() once tests have begun running.*)

I'm happy for you to change this PR before merging it (including dropping it altogether if you would rather do the migration in a different way). 

Thanks!